### PR TITLE
Add scoring weights for roles

### DIFF
--- a/HackathonWebApp/Models/ScoreQuestion.cs
+++ b/HackathonWebApp/Models/ScoreQuestion.cs
@@ -22,6 +22,12 @@ namespace HackathonWebApp.Models
         public string Group {get; set; }
         [Required]
         public Dictionary<string, AnswerOption> AnswerOptions {get; set; }
+
+        // Methods
+        public override string ToString()
+        {
+            return $"{Title} ({PossiblePoints})";
+        }
     }
 
     [BsonIgnoreExtraElements]

--- a/HackathonWebApp/Models/ScoringRole.cs
+++ b/HackathonWebApp/Models/ScoringRole.cs
@@ -18,6 +18,10 @@ namespace HackathonWebApp.Models
         [BsonElement("description")]
         public string Description { get; set; }
 
+        [BsonElement("scoring_weight")]
+        [Range(0.0, 1.0)]
+        public double ScoringWeight { get; set; }
+
         [BsonElement("score_question_ids")]
         public List<string> ScoreQuestionsIds { get; set; }
     }

--- a/HackathonWebApp/Models/ScoringRole.cs
+++ b/HackathonWebApp/Models/ScoringRole.cs
@@ -24,5 +24,11 @@ namespace HackathonWebApp.Models
 
         [BsonElement("score_question_ids")]
         public List<string> ScoreQuestionsIds { get; set; }
+
+        // Methods
+        public override string ToString()
+        {
+            return $"{Name} ({ScoringWeight})";
+        }
     }
 }

--- a/HackathonWebApp/Models/Team.cs
+++ b/HackathonWebApp/Models/Team.cs
@@ -236,6 +236,21 @@ namespace HackathonWebApp.Models
             );
             return avgWeightedScoresByQuestionIdGroupedByRole;
         }}
+        [BsonIgnore]
+        public Dictionary<string, double> AvgWeightedScoresByQuestionId2 { get {
+            // Get the average scores for each role, then sum them together.
+            var avgScoresByQuestion = AvgWeightedScoresByQuestionGroupedByRole.SelectMany(p => p.Value) // Flatten, ignoring roles
+                                    .GroupBy(questionGroup => questionGroup.Key)
+                                    .ToDictionary(
+                                        questionGroup=> questionGroup.Key, // Store results by question
+                                        questionGroup=> questionGroup.Sum(p=> p.Value) // Sum scores for that question
+                                    );
+
+            // Restructure to use question id
+            var avgScoresbyQuestionId = avgScoresByQuestion.ToDictionary(kvp=> kvp.Key.Id.ToString(), kvp=> kvp.Value);
+            return avgScoresbyQuestionId;
+        }
+        }
         #endregion
     }
 }

--- a/HackathonWebApp/Models/Team.cs
+++ b/HackathonWebApp/Models/Team.cs
@@ -220,7 +220,22 @@ namespace HackathonWebApp.Models
                 return weightedScores;
             }
         }
+        [BsonIgnore]
+        public Dictionary<ScoringRole, Dictionary<ScoreQuestion, double>> AvgWeightedScoresByQuestionGroupedByRole { get {
+            // Group the scores by role
+            var groupedScoresByRole = this.WeightedScores.GroupBy(p=> p.Role);
 
+            // Within each role, group by question, then find the average score for each question.
+            var avgWeightedScoresByQuestionIdGroupedByRole = groupedScoresByRole.ToDictionary(
+                roleGroup=> roleGroup.Key, // Store results using role as key
+                roleGroup=> roleGroup // Provide all scores related to this role to next step
+                    .GroupBy(kvQ => kvQ.Question).ToDictionary(
+                        questionGroup => questionGroup.Key, // Store results using question as key
+                        questionGroup => questionGroup.Average(s=> s.CalculatedScore) // Calculate average score for this question
+                    )
+            );
+            return avgWeightedScoresByQuestionIdGroupedByRole;
+        }}
         #endregion
     }
 }

--- a/HackathonWebApp/Models/Team.cs
+++ b/HackathonWebApp/Models/Team.cs
@@ -136,59 +136,6 @@ namespace HackathonWebApp.Models
             return counts;
         }}
         [BsonIgnore]
-        public Dictionary<string, double> AvgUnweightedScoresByQuestionId { get {
-            var counts = new Dictionary<string, int>();
-            var sums = new Dictionary<string, int>();
-            var avgs = new Dictionary<string, double>();
-
-            foreach(var scoreSubmission in this.ScoringSubmissions.Values)
-            {
-                foreach(var kvp in scoreSubmission.Scores) {
-                    string questionId = kvp.Key;
-                    int score = kvp.Value;
-                    if (!sums.Keys.Contains(questionId))
-                    {
-                        counts[questionId] = 0;
-                        sums[questionId] = 0;
-                    }
-                    // Track count and sum
-                    counts[questionId] += 1;
-                    sums[questionId] += score;
-                }
-            }
-
-            // Calculate average
-            foreach (var kvp in sums)
-            {
-                avgs[kvp.Key] = sums[kvp.Key] / (double) counts [kvp.Key];
-            }
-
-            return avgs;
-        }}
-        [BsonIgnore]
-        public Dictionary<string, double> AvgWeightedScoresByQuestionId { get {
-            // Return unweighted scores if no reference event
-            if (this.ReferenceEvent == null)
-            {
-                return this.AvgUnweightedScoresByQuestionId;
-            }
-
-            // Get unweighted averages
-            var unweightedScores = this.AvgUnweightedScoresByQuestionId;
-
-            // Multiply by weight of each question
-            var questions =  this.ReferenceEvent.ScoringQuestions;
-            Dictionary<string, double> weightedScores = unweightedScores.ToDictionary(kvp=> kvp.Key, kvp=> (kvp.Value/5.0)*questions[kvp.Key].PossiblePoints);
-
-            return weightedScores;
-        }}
-        [BsonIgnore]
-        public double CombinedScore {get {
-            return this.AvgWeightedScoresByQuestionId.Values.Sum();
-        }}
-
-
-        [BsonIgnore]
         public List<WeightedScore> WeightedScores {
             get {
                 List<WeightedScore> weightedScores = new List<WeightedScore>();
@@ -237,7 +184,7 @@ namespace HackathonWebApp.Models
             return avgWeightedScoresByQuestionIdGroupedByRole;
         }}
         [BsonIgnore]
-        public Dictionary<string, double> AvgWeightedScoresByQuestionId2 { get {
+        public Dictionary<string, double> AvgWeightedScoresByQuestionId { get {
             // Get the average scores for each role, then sum them together.
             var avgScoresByQuestion = AvgWeightedScoresByQuestionGroupedByRole.SelectMany(p => p.Value) // Flatten, ignoring roles
                                     .GroupBy(questionGroup => questionGroup.Key)
@@ -251,6 +198,10 @@ namespace HackathonWebApp.Models
             return avgScoresbyQuestionId;
         }
         }
+        [BsonIgnore]
+        public double CombinedScore {get {
+            return this.AvgWeightedScoresByQuestionId.Values.Sum();
+        }}
         #endregion
     }
 }

--- a/HackathonWebApp/Models/Team.cs
+++ b/HackathonWebApp/Models/Team.cs
@@ -186,6 +186,41 @@ namespace HackathonWebApp.Models
         public double CombinedScore {get {
             return this.AvgWeightedScoresByQuestionId.Values.Sum();
         }}
+
+
+        [BsonIgnore]
+        public List<WeightedScore> WeightedScores {
+            get {
+                List<WeightedScore> weightedScores = new List<WeightedScore>();
+
+                // Collect all scores from each submission and convert
+                foreach(var kvp in ScoringSubmissions)
+                {
+                    string userId = kvp.Key;
+                    ScoringSubmission scoringSubmision = kvp.Value;
+
+                    // Get user's role during scoring
+                    string scoringRoleId = this.ReferenceEvent.UserScoringRoles[userId];
+                    ScoringRole scoringRole = this.ReferenceEvent.ScoringRoles[scoringRoleId];
+
+                    // Create weighted score objects
+                    foreach(var kvp2 in scoringSubmision.Scores)
+                    {
+                        string questionId = kvp2.Key;
+                        int score = kvp2.Value;
+
+                        // Get question using question id
+                        ScoreQuestion question = this.ReferenceEvent.ScoringQuestions[questionId];
+
+                        var weightedScore = new WeightedScore(score, scoringRole, question);
+                        weightedScores.Add(weightedScore);
+                    }
+                }
+
+                return weightedScores;
+            }
+        }
+
         #endregion
     }
 }

--- a/HackathonWebApp/Models/WeightedScore.cs
+++ b/HackathonWebApp/Models/WeightedScore.cs
@@ -1,0 +1,37 @@
+﻿using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace HackathonWebApp.Models
+{
+    public class WeightedScore
+    {
+        // Fields
+        public int UnweightedScore { get; set; }
+        public ScoringRole Role { get; set; }
+        public ScoreQuestion Question { get; set; }
+
+        // Constructor
+        public WeightedScore(int unweightedScore, ScoringRole role, ScoreQuestion question)
+        {
+            this.UnweightedScore = unweightedScore;
+            this.Role = role;
+            this.Question = question;
+        }
+
+        // Properties
+        public double CalculatedScore { get {
+            double questionPts = UnweightedScore/5.0 * Question.PossiblePoints;
+            double pts = questionPts * Role.ScoringWeight;
+            return pts;
+        }}
+
+        // Override
+        public override string ToString() {
+            return $"{CalculatedScore} = ({UnweightedScore}/5.0)*{Question.PossiblePoints}*{Role.ScoringWeight}";
+        }
+
+
+    }
+}

--- a/HackathonWebApp/Models/WeightedScore.cs
+++ b/HackathonWebApp/Models/WeightedScore.cs
@@ -29,7 +29,7 @@ namespace HackathonWebApp.Models
 
         // Override
         public override string ToString() {
-            return $"{CalculatedScore} = ({UnweightedScore}/5.0)*{Question.PossiblePoints}*{Role.ScoringWeight}";
+            return $"{CalculatedScore} = ({UnweightedScore}/5.0)*{Question.PossiblePoints}*{Role.ScoringWeight}, R:{Role.Name}, Q:{Question.Title}";
         }
 
 

--- a/HackathonWebApp/Views/Scoring/CreateScoringRole.cshtml
+++ b/HackathonWebApp/Views/Scoring/CreateScoringRole.cshtml
@@ -23,6 +23,11 @@
                     <span asp-validation-for="Description" class="text-danger"></span>
                 </div>
                 <div class="form-group">
+                    <label asp-for="ScoringWeight" class="control-label"></label>
+                    <input asp-for="ScoringWeight" class="form-control" />
+                    <span asp-validation-for="ScoringWeight" class="text-danger"></span>
+                </div>
+                <div class="form-group">
                     Questions
                     <table>
                     @foreach (var scoreQuestion in scoringQuestions.Values)

--- a/HackathonWebApp/Views/Scoring/ScoringDashboard.cshtml
+++ b/HackathonWebApp/Views/Scoring/ScoringDashboard.cshtml
@@ -15,7 +15,7 @@
 		return delimetedString;
 	}
     string ToChartTeamsScoresArray(Dictionary<string, Team> teams) {
-        var combinedScores = teams.Values.Select(t=> t.CombinedScore);
+        var combinedScores = teams.Values.Select(t=> Math.Round(t.CombinedScore,2));
 		string delimetedString = "["+String.Join(",", combinedScores)+"]";
 		return delimetedString;
 	}
@@ -34,7 +34,7 @@
 		return delimetedString;
 	}
     string ToChartAvgsDataArray(Team team) {
-        var dataPoints = team.AvgWeightedScoresByQuestionId.Values;
+        var dataPoints = team.AvgWeightedScoresByQuestionId.Values.Select(v => Math.Round(v,2));
 		string delimetedString = "["+String.Join(",", dataPoints)+"]";
 		return delimetedString;
 	}

--- a/HackathonWebApp/Views/Scoring/ScoringRoles.cshtml
+++ b/HackathonWebApp/Views/Scoring/ScoringRoles.cshtml
@@ -32,6 +32,7 @@
         <tr>
             <td>
                 <div class="role-name">@scoringRole.Name</div>
+                <div class="role-description">Scoring Weight: @scoringRole.ScoringWeight</div>
                 <div class="role-description">@scoringRole.Description</div>
             </td>
             <td>

--- a/HackathonWebApp/Views/Scoring/UpdateScoringRole.cshtml
+++ b/HackathonWebApp/Views/Scoring/UpdateScoringRole.cshtml
@@ -25,6 +25,11 @@
                     <span asp-validation-for="Description" class="text-danger"></span>
                 </div>
                 <div class="form-group">
+                    <label asp-for="ScoringWeight" class="control-label"></label>
+                    <input asp-for="ScoringWeight" class="form-control" />
+                    <span asp-validation-for="ScoringWeight" class="text-danger"></span>
+                </div>
+                <div class="form-group">
                     Questions
                     <table>
                     @foreach (var scoreQuestion in scoringQuestions.Values)

--- a/HackathonWebAppTests/Models/TeamTests.cs
+++ b/HackathonWebAppTests/Models/TeamTests.cs
@@ -357,6 +357,23 @@ namespace HackathonWebAppTests
             Assert.Equal(6, participantScoresByQuestion[q4]);
             Assert.Equal(3.75, participantScoresByQuestion[q5]);
         }
+        
+        [Fact]
+        public void AvgWeightedScoresByQuestionId2() {
+            // Define
+            var hackathonEvent = SampleData.SampleHackathonEvent_Scoring;
+            var team = hackathonEvent.Teams["000000000000000000000111"];
+
+            // Process
+            var avgScores = team.AvgWeightedScoresByQuestionId2;
+
+            // Assert
+            Assert.Equal(0.8,  avgScores["000000000000000000000001"]);
+            Assert.Equal(1.8,  avgScores["000000000000000000000002"]);
+            Assert.Equal(9.6,  avgScores["000000000000000000000003"]);
+            Assert.Equal(8.0,  avgScores["000000000000000000000004"]);
+            Assert.Equal(3.75, avgScores["000000000000000000000005"]);
+        }
         #endregion
 
         # region Experience

--- a/HackathonWebAppTests/Models/TeamTests.cs
+++ b/HackathonWebAppTests/Models/TeamTests.cs
@@ -220,61 +220,7 @@ namespace HackathonWebAppTests
             Assert.Equal(2, countScores["000000000000000000000005"]);
         }
 
-        /// <summary>
-        /// Description: Verifies that multiple score submission across several questions can be properally averaged.
-        /// </summary> 
-        [Fact]
-        public void AvgUnweightedScoresByQuestionId() {
-            // Define
-            var hackathonEvent = SampleData.SampleHackathonEvent_Scoring;
-            var team = hackathonEvent.Teams["000000000000000000000111"];
-
-            // Process
-            var avgScores = team.AvgUnweightedScoresByQuestionId;
-
-            // Assert
-            Assert.Equal(2,             avgScores["000000000000000000000001"]);
-            Assert.Equal((1+5)/2.0,     avgScores["000000000000000000000002"]);
-            Assert.Equal((3+5+1+5)/4.0, avgScores["000000000000000000000003"]);
-            Assert.Equal((5+1+5)/3.0,   avgScores["000000000000000000000004"]);
-            Assert.Equal((1+2)/2.0,     avgScores["000000000000000000000005"]);
-        }
-        
-        /// <summary>
-        /// Description: Verifies that multiple score submission across several questions can be properally averaged, incorporating the weight of the question.
-        /// </summary> 
-        [Fact]
-        public void AvgWeightedScoresByQuestionId() {
-            // Define
-            var hackathonEvent = SampleData.SampleHackathonEvent_Scoring;
-            var team = hackathonEvent.Teams["000000000000000000000111"];
-
-            // Process
-            var avgScores = team.AvgWeightedScoresByQuestionId;
-
-            // Assert   score/max_score*PossiblePoints
-            Assert.Equal(2              /5.0 *5,  avgScores["000000000000000000000001"]);
-            Assert.Equal((1+5)/2.0      /5.0 *10, avgScores["000000000000000000000002"]);
-            Assert.Equal((3+5+1+5)/4.0  /5.0 *15, avgScores["000000000000000000000003"]);
-            Assert.Equal((5+1+5)/3.0    /5.0 *20, avgScores["000000000000000000000004"]);
-            Assert.Equal((1+2)/2.0      /5.0 *25, avgScores["000000000000000000000005"]);
-        }
-        /// <summary>
-        /// Description: Verifies that a rollup of all scoring for this team across all questions and their weights is valid.
-        /// </summary> 
-        [Fact]
-        public void CombinedScore() {
-            // Define
-            var hackathonEvent = SampleData.SampleHackathonEvent_Scoring;
-            var team = hackathonEvent.Teams["000000000000000000000111"];
-
-            // Process
-            var score = team.CombinedScore;
-
-            // Assert   score/max_score*PossiblePoints
-            Assert.Equal(40.67, Math.Round(score, 2));
-        }
-        
+       
         
         /// <summary>
         /// Description: Verifies that multiple score submission across several questions can be properally counted.
@@ -303,6 +249,11 @@ namespace HackathonWebAppTests
             Assert.Equal((2/5.0)*25*0.5, weightedScores[11].CalculatedScore);
         }
         
+        /// <summary>
+        /// Description: Verifies that scores can be averaged and grouped properly.
+        /// - Scores are grouped by Role.
+        /// - Within a role, scores are averaged by the question.
+        /// </summary> 
         [Fact]
         public void AvgWeightedScoresByQuestionGroupedByRole() {
             // Define
@@ -358,14 +309,24 @@ namespace HackathonWebAppTests
             Assert.Equal(3.75, participantScoresByQuestion[q5]);
         }
         
+        /// <summary>
+        /// Description: Verifies that scores can be averaged and grouped properly.
+        /// - Scores are grouped by Role.
+        /// - Within a role, scores are averaged by the question.
+        /// - Average scores for each question are summed together across roles.
+        /// Example: Judge has 0.4 weight. Participant has 0.5 weight. Question1 is worth 10pts.
+        /// Judge's score of 3/5 on Q1 => 6pts.
+        /// Participant's score of 4/5 on Q1 => 8pts
+        // Judge's 6pts * 0.4 + Participant's 8pts*0.5 => 2.4 + 4pts => 6.4pts combined score
+        /// </summary> 
         [Fact]
-        public void AvgWeightedScoresByQuestionId2() {
+        public void AvgWeightedScoresByQuestionId() {
             // Define
             var hackathonEvent = SampleData.SampleHackathonEvent_Scoring;
             var team = hackathonEvent.Teams["000000000000000000000111"];
 
             // Process
-            var avgScores = team.AvgWeightedScoresByQuestionId2;
+            var avgScores = team.AvgWeightedScoresByQuestionId;
 
             // Assert
             Assert.Equal(0.8,  avgScores["000000000000000000000001"]);
@@ -374,6 +335,23 @@ namespace HackathonWebAppTests
             Assert.Equal(8.0,  avgScores["000000000000000000000004"]);
             Assert.Equal(3.75, avgScores["000000000000000000000005"]);
         }
+        
+        /// <summary>
+        /// Description: Verifies that a rollup of all scoring for this team across all questions and their weights is valid.
+        /// </summary> 
+        [Fact]
+        public void CombinedScore() {
+            // Define
+            var hackathonEvent = SampleData.SampleHackathonEvent_Scoring;
+            var team = hackathonEvent.Teams["000000000000000000000111"];
+
+            // Process
+            var score = team.CombinedScore;
+
+            // Assert   score/max_score*PossiblePoints
+            Assert.Equal(23.95, Math.Round(score, 2));
+        }
+        
         #endregion
 
         # region Experience

--- a/HackathonWebAppTests/Models/WeightedScoreTests.cs
+++ b/HackathonWebAppTests/Models/WeightedScoreTests.cs
@@ -1,0 +1,30 @@
+using System;
+using Xunit;
+using MongoDB.Bson;
+using HackathonWebApp.Models;
+
+
+namespace HackathonWebAppTests
+{
+    public class WeightedScoreTests
+    {
+        /// <summary>
+        /// Description: Verifies that the calculated score is correct.
+        /// </summary> 
+        [Fact]
+        public void Test_CalculatedScore()
+        {
+            // Define
+            int unweightedScore = 3;
+            ScoringRole role = new ScoringRole() { ScoringWeight = 0.6 };
+            ScoreQuestion question = new ScoreQuestion() { PossiblePoints = 30 };
+            
+            // Process
+            var w = new WeightedScore(unweightedScore, role, question);
+            var calculateScore = w.CalculatedScore;
+
+            // Assert
+            Assert.Equal((3/5.0)*30*0.6, calculateScore);
+        }
+    }
+}


### PR DESCRIPTION
- Adds model "WeightedScore" to handle calculation of weighted score considering both question value and role weight.
- Removes older method used for calculating unweighted score based on submitted score (0-5).
- Removes older method used for calculating weighted score based only on question value.
- Adds a method for providing average weighted scores (across a question) grouped by Role.
- Adds a method for providing average weighted scores (across a question) based on Role weight and Question value.
- Tweaks values on charts to be rounded to 2 decimal places.