### PR TITLE
Re-enable page to create account

### DIFF
--- a/HackathonWebApp/Controllers/AccountController.cs
+++ b/HackathonWebApp/Controllers/AccountController.cs
@@ -66,11 +66,21 @@ namespace HackathonWebApp.Controllers
         }
         public IActionResult Create()
         {
+            ViewBag.AccountCreationAllowed = bool.Parse(configuration["ALLOW_CREATING_ACCOUNTS"]);
             return View();
         }
         [HttpPost]
         public async Task<IActionResult> Create(ApplicationUser appUser)
         {
+            // Prevent creating accounts, if disabled
+            bool accountCreationAllowed = bool.Parse(configuration["ALLOW_CREATING_ACCOUNTS"]);
+            if (!accountCreationAllowed)
+            {
+                ModelState.Clear();
+                ModelState.AddModelError("", "Creating accounts is not currently allowed. Please try again closer to the event date.");
+                return View(appUser);
+            }
+
             // Check recaptcha token. If it fails verification, show error message and return to create account page.
             string token = Request.Form["g-recaptcha-token"];
             bool isVerified = await this.VerifyRecaptchaToken(token, 0.5);

--- a/HackathonWebApp/Startup.cs
+++ b/HackathonWebApp/Startup.cs
@@ -44,6 +44,10 @@ namespace HackathonWebApp
             if (Configuration["RECAPTCHA_KEY"] == null)
                 exceptions.Add(new ArgumentNullException("Missing Setting: RECAPTCHA_KEY"));
 
+            // Check optional values and set default if missing
+            if (Configuration["ALLOW_CREATING_ACCOUNTS"] == null)
+                Configuration["ALLOW_CREATING_ACCOUNTS"] = "true";
+
             // Throw exception if any settings are missing
             if (exceptions.Count > 0)
                 throw new AggregateException("Missing Configuration", exceptions);

--- a/HackathonWebApp/Views/Account/Create.cshtml
+++ b/HackathonWebApp/Views/Account/Create.cshtml
@@ -1,7 +1,6 @@
 ﻿@{
     ViewData["Title"] = "Create Account";
-    ViewBag.AccountCreationAllowed = false;
-    bool AccountCreationAllowed = ViewBag.AccountCreationAllowed ?? false;
+    bool accountCreationAllowed = ViewBag.AccountCreationAllowed;
 }
 
 @model ApplicationUser
@@ -21,7 +20,7 @@
     <div asp-validation-summary="All" class="text-danger"></div>
  
     <div class="row">
-        @if(AccountCreationAllowed)
+        @if(accountCreationAllowed)
         {
 
         <div class="col-md-4">
@@ -59,22 +58,6 @@
                 <a id="submit-btn" type="button" class="btn btn-primary">Create</a>
             </form>
         </div>
-        } else
-        {
-        <div class="col-md-4">
-            Um... this is a bit embarassing... we can't help right now. Such a shame. We would love to have you join us. But...we had to disable creating new accounts (for now). 😢
-            <br/>
-            <br/>
-            The bots found our site... and yep... they started spam creating hundreds of accounts. 🤖
-            We knew it would happen eventually, but we didn't expect this fast! 
-            <br/>
-            <br/>
-            Anyway, we are currently doing some upgrades to block them. We'll have registration back up shortly! 🤓
-        </div>
-
-        }
-
-
 
         <div class="col-md-6">
             <h3>Please Note</h3>
@@ -84,6 +67,21 @@
                             
             If you would like to apply for the event at the same time as creating your account, please use the <a asp-area="" asp-controller="Event" asp-action="Apply">Event Registration</a> page.
         </div>
+
+        } else
+        {
+
+        <div class="col-md-8">
+            Thank you for your interest to join the hacking! 🤓<br/>
+            Creating new accounts is currently disabled.<br/>
+            Please come back closer to the event date. ♥️
+        </div>
+
+        }
+
+
+
+        
     </div>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ MONGODB_HACKATHON_DB_NAME=<events collection name>
 EMAIL_USERNAME=<email address>
 EMAIL_PASSWORD=<email password>
 RECAPTCHA_KEY=<private key from google recaptcha service>
+
+# OPTIONAL
+ALLOW_CREATING_ACCOUNTS=true # default: true
 ```
 
 ## Application Configuration


### PR DESCRIPTION
- Added environment variable `ALLOW_CREATING_ACCOUNTS` to enable/disable creating new accounts. Default: true
- Added message to "Create Account" page if current mode does not allow creating new accounts.