### PR TITLE
Add option to login by emailed link

### DIFF
--- a/HackathonWebApp/Controllers/AccountController.cs
+++ b/HackathonWebApp/Controllers/AccountController.cs
@@ -160,6 +160,7 @@ namespace HackathonWebApp.Controllers
                 var r = new Random();
                 appUser.Password = GenerateRandomPassword(r.Next(8, 24));
                 ModelState.Clear();
+                TryValidateModel(appUser);
             }
 
             if (ModelState.IsValid)

--- a/HackathonWebApp/Controllers/AccountController.cs
+++ b/HackathonWebApp/Controllers/AccountController.cs
@@ -366,7 +366,7 @@ namespace HackathonWebApp.Controllers
             var result = await userManager.ConfirmEmailAsync(appUser, code);
             if (!result.Succeeded)
             {
-                ModelState.AddModelError(nameof(userId), "Login Failed: Invalid Invalid user or code");
+                ModelState.AddModelError(nameof(userId), "Login Failed: Invalid user or code");
                 return View (nameof(Login));
             }
 

--- a/HackathonWebApp/Controllers/AccountController.cs
+++ b/HackathonWebApp/Controllers/AccountController.cs
@@ -236,6 +236,8 @@ namespace HackathonWebApp.Controllers
         {
             // Get the user
             var appUser = await userManager.FindByIdAsync(userId);
+            if (appUser == null)
+                return View();
 
             // Check if already confirmed
             bool emailAlreadyConfirmed = await userManager.IsEmailConfirmedAsync(appUser);

--- a/HackathonWebApp/Controllers/AccountController.cs
+++ b/HackathonWebApp/Controllers/AccountController.cs
@@ -115,8 +115,8 @@ namespace HackathonWebApp.Controllers
         public async Task<IActionResult> Create(ApplicationUser appUser)
         {
             // Prevent creating accounts, if disabled
-            bool accountCreationAllowed = bool.Parse(configuration["ALLOW_CREATING_ACCOUNTS"]);
-            if (!accountCreationAllowed)
+            ViewBag.AccountCreationAllowed = bool.Parse(configuration["ALLOW_CREATING_ACCOUNTS"]);
+            if (!ViewBag.AccountCreationAllowed)
             {
                 ModelState.Clear();
                 ModelState.AddModelError("", "Creating accounts is not currently allowed. Please try again closer to the event date.");

--- a/HackathonWebApp/Startup.cs
+++ b/HackathonWebApp/Startup.cs
@@ -66,7 +66,7 @@ namespace HackathonWebApp
 
             // Set timeout for tkens
             services.Configure<DataProtectionTokenProviderOptions>(opt =>
-                opt.TokenLifespan = TimeSpan.FromHours(24));
+                opt.TokenLifespan = TimeSpan.FromMinutes(10));
 
             // Add database for collections
             var mongo_client = new MongoClient(Configuration["MONGODB_URL"]);

--- a/HackathonWebApp/Views/Account/ConfirmAccountEmailSent.cshtml
+++ b/HackathonWebApp/Views/Account/ConfirmAccountEmailSent.cshtml
@@ -11,7 +11,7 @@
         Please Remember:<br/>
         <ul>
             <li>Your account's email must be confirmed to be considered for an event.</li>
-            <li>The verification email expires in 24hrs.</li>
+            <li>The verification email expires in 10min.</li>
             <li>You can use the login page to re-request this verification email.</li>
         </ul>
         <div>

--- a/HackathonWebApp/Views/Account/ConfirmEmail.cshtml
+++ b/HackathonWebApp/Views/Account/ConfirmEmail.cshtml
@@ -25,8 +25,10 @@
 
         default:
             <p>
-            <span style="color:red;">Invalid confirmation code</span> for the given account. <br/>
+            <span style="color:red;">Invalid or expired confirmation code</span><br/>
             Please check your email for a confirmation link.
+            <br/>
+            If the confirmation link has expired, you can <a href="/Account/ConfirmAccount">request another confirmation email</a> at the login page.
             </p>
             break;
     }

--- a/HackathonWebApp/Views/Account/ConfirmLoginEmailSent.cshtml
+++ b/HackathonWebApp/Views/Account/ConfirmLoginEmailSent.cshtml
@@ -1,0 +1,16 @@
+﻿@{
+    ViewBag.Title = "Confirm Account - Email Sent";
+}
+
+<div class="container text-white col-sm-6">
+    <div class="col-12" style="background-color:var(--bh-dark-green-gray); border:1px solid var(--bh-green); border-radius:10px; padding:15px; 10px">
+        <h3>Quick Login</h3>
+        <div>You should receive an emailed link shortly that will auto-magically log you in. 🧙</div>
+        <br/>
+        <ul>
+            <li>The login link expires in 24hrs.</li>
+            <li>You can use the <a href="/account/login" target="_blank">login</a> page to request another link.</li>
+            <li>If no account exists, the request will be ignored.<br/>If needed, please <a href="/account/create" target="_blank">create an account</a>.</li>
+        </ul>
+    </div>
+</div>

--- a/HackathonWebApp/Views/Account/ConfirmLoginEmailSent.cshtml
+++ b/HackathonWebApp/Views/Account/ConfirmLoginEmailSent.cshtml
@@ -8,7 +8,7 @@
         <div>You should receive an emailed link shortly that will auto-magically log you in. 🧙</div>
         <br/>
         <ul>
-            <li>The login link expires in 24hrs.</li>
+            <li>The login link expires in 10min.</li>
             <li>You can use the <a href="/account/login" target="_blank">login</a> page to request another link.</li>
             <li>If no account exists, the request will be ignored.<br/>If needed, please <a href="/account/create" target="_blank">create an account</a>.</li>
         </ul>

--- a/HackathonWebApp/Views/Account/Create.cshtml
+++ b/HackathonWebApp/Views/Account/Create.cshtml
@@ -61,11 +61,15 @@
 
         <div class="col-md-6">
             <h3>Please Note</h3>
-            <p>Creating an account does <b><u>not</u></b> automatically register you for the upcoming event.
-            It just makes registering for future events easier.
+            <p>
+            Creating an account does <b><u>not</u></b> register you for the upcoming event.
+            You can register for the event <b><u>after</u></b> you have an account.
             </p>
-                            
-            If you would like to apply for the event at the same time as creating your account, please use the <a asp-area="" asp-controller="Event" asp-action="Apply">Event Registration</a> page.
+
+            <p>
+            A password is optional. There is an option to login via an emailed link.
+            And, a new password can be set by using the <a href="/Account/ForgotPassword" target="_blank">Forgot Password</a> form.
+            </p>
         </div>
 
         } else

--- a/HackathonWebApp/Views/Account/Create.cshtml
+++ b/HackathonWebApp/Views/Account/Create.cshtml
@@ -46,13 +46,13 @@
                     <input asp-for="Email" class="form-control" placeholder="obiwan@jedimasters.net"/>
                 </div>
                 <div class="form-group">
-                    Password
+                    Password (optional)
                     <input asp-for="Password" type="password" class="form-control" placeholder="Choose a password"/>
                     <ul class="subinfo">
                         <li>Min 6 characters.</li>
-                        <li>Min one non alphanumeric character.</li>
-                        <li>Min one digit ('0'-'9').</li>
-                        <li>Min one uppercase ('A'-'Z').</li>
+                        <li>Min one special character.</li>
+                        <li>Min one digit (0-9).</li>
+                        <li>Min one uppercase (A-Z).</li>
                     </ul>
                 </div>
                 <a id="submit-btn" type="button" class="btn btn-primary">Create</a>

--- a/HackathonWebApp/Views/Account/Login.cshtml
+++ b/HackathonWebApp/Views/Account/Login.cshtml
@@ -2,24 +2,62 @@
     ViewData["Title"] = "Login";
 }
 
+<style>
+    #login-tabs-buttons {
+        border: 0;
+    }
+    #login-tabs-buttons .nav-link {
+        border: 1px solid var(--bh-green);
+        border-radius: 10px 10px 0 0;
+    }
+    #login-tabs-buttons .nav-link.active {
+        color: var(--osu-orange);
+        background-color: var(--bh-dark-green-gray);
+        border-bottom: 0;
+    }
+    #login-tabs-content {
+        background-color: var(--bh-dark-green-gray);
+        border: 1px solid var(--bh-green);
+        border-top: 0;
+        border-radius: 0 0 10px 10px;
+        padding: 15px; 10px;
+    }
+</style>
+
 <div class="container text-white">
     <h1 class="text-white">Login</h1>
     <div class="text-danger" asp-validation-summary="All"></div>
  
     <div class="row">
-        <div class="col-md-4">
-            <form id="login-form" method="post">
-                <div class="form-group">
-                    <label>Email</label>
-                    <input name="email" class="form-control" />
+        <div class="col-lg-4 col-md-5 col-sm-8">
+            @* Tabs: Options *@
+            <ul id="login-tabs-buttons" class="nav nav-tabs nav-fill">
+                <li class="nav-item"><a href="" data-target="#WithPassword" data-toggle="tab" class="nav-link small text-uppercase active">With Password</a></li>
+                <li class="nav-item"><a href="" data-target="#SendLoginEmail" data-toggle="tab" class="nav-link small text-uppercase">Emailed Link</a></li>
+            </ul>
+            
+            @* Login Forms *@
+            <div id="login-tabs-content" class="tab-content" style="">
+                @* By Password *@
+                <div id="WithPassword" class="tab-pane fade show active">
+                    <form class="login-form" method="post" action="">
+                        <input name="email" class="form-control" placeholder="Email" />
+                        <input name="password" type="password" class="form-control" placeholder="Password" style="margin-top:5px;"/>
+                        <a id="submit-btn" type="button" class="btn btn-primary" style="margin-top:10px;">Login</a>
+                    </form>
                 </div>
-                <div class="form-group">
-                    <label>Password</label>
-                    <input name="password" type="password" class="form-control" />
+                
+                @* By Email Link *@
+                <div id="SendLoginEmail" class="tab-pane fade">
+                    <form class="login-form" method="post" action="SendLoginEmail">
+                        <input name="email" class="form-control" placeholder="Email" value="christopher.blake@bakerhughes.com"/>
+                        <a id="submit-btn" type="button" class="btn btn-primary" style="margin-top:10px;">Send login link</a>
+                    </form>
                 </div>
-                <a id="submit-btn" type="button" class="btn btn-primary">Login In</a>
-            </form>
-            <br/>
+            </div>
+        </div>
+
+        <div class="col-md-4" style="padding-top:5px;">
             or... <a class="" asp-controller="Account" asp-action="Create">Create an Account</a>
             <br/>
             or... <a class="" asp-controller="Account" asp-action="ForgotPassword">Forgot Password</a>
@@ -32,7 +70,7 @@
 @section Scripts {
     <script>
     $( document ).ready(function() {
-        $("#login-form").find("#submit-btn").click(function(e){
+        $(".login-form").find("#submit-btn").click(function(e){
             e.preventDefault();
             // Identify submit button and form
             var btn = $(this);

--- a/HackathonWebApp/Views/Account/Login.cshtml
+++ b/HackathonWebApp/Views/Account/Login.cshtml
@@ -50,7 +50,7 @@
                 @* By Email Link *@
                 <div id="SendLoginEmail" class="tab-pane fade">
                     <form class="login-form" method="post" action="SendLoginEmail">
-                        <input name="email" class="form-control" placeholder="Email" value="christopher.blake@bakerhughes.com"/>
+                        <input name="email" class="form-control" placeholder="Email"/>
                         <a id="submit-btn" type="button" class="btn btn-primary" style="margin-top:10px;">Send login link</a>
                     </form>
                 </div>

--- a/HackathonWebApp/Views/Event/Apply.cshtml
+++ b/HackathonWebApp/Views/Event/Apply.cshtml
@@ -49,45 +49,6 @@
     <div class="row">
         <div class="col-sm-8 col-md-6 col-lg-5">
             <form asp-action="Apply">
-                @if ((User?.Identity?.IsAuthenticated ?? false) == false)
-                {
-                <h3>Create Account</h3>
-                <div class="qa-section-box">
-                    <div class="form-group">
-                        First Name
-                        <input asp-for="AssociatedUser.FirstName" class="form-control" placeholder="Ben"/>
-                        <span asp-validation-for="AssociatedUser.FirstName" class="text-danger"></span>
-                    </div>
-                    <div class="form-group">
-                        Last name
-                        <input asp-for="AssociatedUser.LastName" class="form-control" placeholder="Kenobi"/>
-                        <span asp-validation-for="AssociatedUser.LastName" class="text-danger"></span>
-                    </div>
-                    <div class="form-group">
-                        Username
-                        <input asp-for="AssociatedUser.UserName" class="form-control" placeholder="ObiWan"/>
-                        <span asp-validation-for="AssociatedUser.UserName" class="text-danger"></span>
-                    </div>
-                    <div class="form-group">
-                        Email
-                        <input asp-for="AssociatedUser.Email" class="form-control" placeholder="obiwan@jedimasters.com"/>
-                        <span asp-validation-for="AssociatedUser.Email" class="text-danger"></span>
-                    </div>
-                    <div class="form-group">
-                        Password
-                        <input asp-for="AssociatedUser.Password" type="password" class="form-control" placeholder="Choose a password"/>
-                        <span asp-validation-for="AssociatedUser.Password" class="text-danger"></span>
-                        <ul class="subinfo">
-                            <li>Min 6 characters.</li>
-                            <li>Min one non alphanumeric character.</li>
-                            <li>Min one digit ('0'-'9').</li>
-                            <li>Min one uppercase ('A'-'Z').</li>
-                        </ul>
-                    </div>
-                    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-                </div>
-                }
-
                 <h3>School Information</h3>
                 <div class="qa-section-box">
                     <p>Major</p>

--- a/HackathonWebApp/Views/Event/ThankYou.cshtml
+++ b/HackathonWebApp/Views/Event/ThankYou.cshtml
@@ -15,7 +15,7 @@
         {
         <div>
             🚧🚧🚧<br/>
-            Please remember to reply, within 24hrs, to the <span style="color:var(--osu-orange)">account verification email!</span><br/>
+            Please remember to confim your account using <span style="color:var(--osu-orange)">the sent verification email!</span><br/>
             <span style="color:var(--osu-orange)">Otherwise, we cannot consider your application!</span> 🤷‍♀️😥<br/>
         </div>
         }

--- a/HackathonWebApp/Views/Event/UpdateHackathonEvent.cshtml
+++ b/HackathonWebApp/Views/Event/UpdateHackathonEvent.cshtml
@@ -107,7 +107,7 @@
                 <div class="form-group">
                     @{ var tShirtSizeOptionsText = String.Join("\n", hackathonEvent.RegistrationSettings.TShirtSizeOptions.Values).Trim(); }
                     <label class="control-label" for="TShirtSizeOptions">T-Shirt Size Options</label>
-                    <textarea style="width:100%;" id="TShirtSizeOptions" name="TShirtSizeOptions">@tShirtSizeOptionsText</textarea>
+                    <textarea style="width:100%;" id="TShirtSizeOptions" name="TShirtSizeOptions" sort="false">@tShirtSizeOptionsText</textarea>
                 </div>
 
                 <h2>Team Settings</h2>
@@ -181,10 +181,14 @@
 
         // Regenerate hidden inputs
         var optionsText = optionsTextArea.val();
-        var optionsList = optionsText.split("\n")
-            .filter(a=>a) // remove blanks
-            .sort(function (a, b) { return a.toLowerCase().localeCompare(b.toLowerCase());
-            });
+        var optionsList = optionsText.split("\n").filter(a=>a); // remove blanks
+
+        // Default to sorting options alphanumerically, unless there is a flag that prevents it.
+        var sortOptions = optionsTextArea.attr('sort');
+        if (sortOptions == undefined || sortOptions.toLowerCase() === "true" )
+            optionsList = optionsList.sort(function (a, b) { return a.toLowerCase().localeCompare(b.toLowerCase());});
+
+        // Append each item as a hidden field
         $.each(optionsList.reverse(), function(index, value) {
             var option = value.replace(/[^a-zA-Z0-9 ]/g, '').trim();
             var key = option.toLowerCase().replace(/ /g, '_').trim();

--- a/HackathonWebApp/wwwroot/email-templates/ConfirmAvailability.html
+++ b/HackathonWebApp/wwwroot/email-templates/ConfirmAvailability.html
@@ -31,7 +31,7 @@
                     </tr>
                 </table>
                 <br/>
-                <span style="font-size:small;">*These links will expire in 24hrs.</span>
+                <span style="font-size:small;">*These links will expire in 10min.</span>
                 <br/>
                 <span style="font-size:small;">*You can also confirm availability on your <a href="{3}" target="_blank">account</a> page.</span>
             </td>

--- a/HackathonWebApp/wwwroot/email-templates/ConfirmEmailAddress.html
+++ b/HackathonWebApp/wwwroot/email-templates/ConfirmEmailAddress.html
@@ -26,7 +26,7 @@
                     </tr>
                 </table>
                 <br/>
-                <span style="font-size:small;">*This link will expire in 24hrs.</span>
+                <span style="font-size:small;">*This link will expire in 10min.</span>
                 <br/>
             </td>
         </tr>

--- a/HackathonWebApp/wwwroot/email-templates/ForgotPassword.html
+++ b/HackathonWebApp/wwwroot/email-templates/ForgotPassword.html
@@ -28,7 +28,7 @@
                     </tr>
                 </table>
                 <br/>
-                <span style="font-size:small;">*This link will expire in 24hrs.</span>
+                <span style="font-size:small;">*This link will expire in 10min.</span>
             </td>
         </tr>
     </table>

--- a/HackathonWebApp/wwwroot/email-templates/LoginByEmailLink.html
+++ b/HackathonWebApp/wwwroot/email-templates/LoginByEmailLink.html
@@ -1,0 +1,40 @@
+<html>
+
+<body style="background-color:transparent; padding: 10px; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji'">
+    <center>
+    <table style="border: 1px solid #018374; width: 460px; border-collapse: collapse;">
+        <tr>
+            <td style="background-color: #018374; padding: 50px 50px 20px 50px; text-align: center;">
+                <img src="https://hackokstate.com/img/hackokstate.png" style="width:100%;">
+            </td>
+        </tr>
+        <tr>
+            <td style="padding: 20px; text-align: center; background-color: #ddd;">
+                <h2>Hi {0}!</h2>
+                Welcome back! 👋
+                <br/>
+                <br/>
+                Here is your requested login link!<br/>
+                It will automatically log you in and send you to your profile. 
+                <br/>
+                <br/>
+                Now... let's get back to some fun hacking!
+                <h2>⚙👨‍🚀✈🏛👩‍💻👨‍🏭🩺🦸‍♀️🤓🚀💃🚧🕺</h2>
+                
+                <table style="display: inline-block;">
+                    <tr>
+                        <td style="padding:10px 30px 10px 30px; background-color:#FE5C00; border:1px solid #05322B; border-radius:5px;">
+                            <a href="{1}" target="_blank" style="color:black;  text-decoration:none;">Login (auto-magically)</a>
+                        </td>
+                    </tr>
+                </table>
+                <br/>
+                <span style="font-size:small;">*This link will expire in 24hrs.</span>
+                <br/>
+            </td>
+        </tr>
+    </table>
+    </center>
+</body>
+
+</html>

--- a/HackathonWebApp/wwwroot/email-templates/LoginByEmailLink.html
+++ b/HackathonWebApp/wwwroot/email-templates/LoginByEmailLink.html
@@ -29,7 +29,7 @@
                     </tr>
                 </table>
                 <br/>
-                <span style="font-size:small;">*This link will expire in 24hrs.</span>
+                <span style="font-size:small;">*This link will expire in 10min.</span>
                 <br/>
             </td>
         </tr>


### PR DESCRIPTION
- Adds a login method that allows a user to request a login link via email.
- Adds supporting methods to generate and send an email with a token, allowing a user to login via a generated link.
- Adjust `password` field on account creation to be optional.
- Reduced length of verification tokens to 10 minutes.

### Bugs
- Removes ability to create an account during event registration. It was very buggy.
- Fixed an issue that did not revalidate the event registration model.
- Adds a hidden sorting option to the "Update Hackathon Event" page to store entries in alphabetic order, defaulting to true.
- Disables sorting of t-shirt options for the "Update Hackathon Event" page.
- Fixed crash if ConfirmEmail page is accessed and no user is logged in.
- Fixed some typos.
